### PR TITLE
Agregar mensaje de envio y remover descarga

### DIFF
--- a/core/static/css/style.css
+++ b/core/static/css/style.css
@@ -111,3 +111,24 @@ hr {
   border: none;
   border-top: 1px solid #eee;
 }
+
+/* —— Ventana emergente —— */
+.popup-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0,0,0,0.5);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+.popup {
+  background: var(--color-surface);
+  padding: 1rem 1.5rem;
+  border-radius: 0.25rem;
+  max-width: 90%;
+  text-align: center;
+}

--- a/core/templates/core/formulario.html
+++ b/core/templates/core/formulario.html
@@ -234,4 +234,19 @@
 
     <button type="submit" class="btn-primary">Generar Informe</button>
   </form>
+
+  {% if mensaje_exito %}
+  <div id="popup-overlay" class="popup-overlay">
+    <div class="popup">
+      <p>Informe enviado con éxito</p>
+      <button id="popup-close" class="btn-primary">Cerrar</button>
+    </div>
+  </div>
+  <script>
+    document.getElementById('popup-overlay').style.display = 'flex';
+    document.getElementById('popup-close').addEventListener('click', function(){
+      document.getElementById('popup-overlay').style.display = 'none';
+    });
+  </script>
+  {% endif %}
 {% endblock %}

--- a/core/views.py
+++ b/core/views.py
@@ -1,5 +1,4 @@
 from django.shortcuts import render
-from django.http import HttpResponse
 from .forms import ReporteForm
 from docxtpl import DocxTemplate, InlineImage
 from docx.shared import Mm
@@ -95,13 +94,13 @@ def formulario_view(request):
                 except:
                     pass
 
-            # Siempre devolver el archivo
-            resp = HttpResponse(
-                data,
-                content_type='application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+            # Mostrar confirmación al usuario
+            form = ReporteForm()  # Reiniciar formulario vacío
+            return render(
+                request,
+                'core/formulario.html',
+                {'form': form, 'mensaje_exito': True}
             )
-            resp['Content-Disposition'] = f'attachment; filename="informe_{cd["parque"]}.docx"'
-            return resp
 
     else:
         form = ReporteForm()


### PR DESCRIPTION
## Summary
- return a confirmation instead of serving the generated file
- show the confirmation in a modal popup
- style popup overlay

## Testing
- `python manage.py check`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6855e75e8b508330849c89f52d99b6ef