### PR TITLE
Add login page requiring credentials

### DIFF
--- a/core/static/css/style.css
+++ b/core/static/css/style.css
@@ -132,3 +132,10 @@ hr {
   max-width: 90%;
   text-align: center;
 }
+
+/* —— Mensajes de error —— */
+.error-message {
+  color: red;
+  text-align: center;
+  margin-bottom: 1rem;
+}

--- a/core/templates/base.html
+++ b/core/templates/base.html
@@ -16,9 +16,11 @@
       <nav class="main-nav">
         <a href="#" class="active">Inicio</a>
       </nav>
+      {% if nombre %}
       <div class="user-info">
         Bienvenido(a), {{ nombre }}
       </div>
+      {% endif %}
     </div>
   </header>
 

--- a/core/templates/core/login.html
+++ b/core/templates/core/login.html
@@ -1,0 +1,20 @@
+{% extends 'base.html' %}
+{% block title %}Acceso – Aediles{% endblock %}
+{% block content %}
+  <h1>Ingreso</h1>
+  <form method="post">
+    {% csrf_token %}
+    {% if error %}
+      <p class="error-message">Credenciales inválidas</p>
+    {% endif %}
+    <div class="form-group">
+      <label for="username">Usuario</label>
+      <input type="text" id="username" name="username" class="form-control" required>
+    </div>
+    <div class="form-group">
+      <label for="password">Contraseña</label>
+      <input type="password" id="password" name="password" class="form-control" required>
+    </div>
+    <button type="submit" class="btn-primary">Ingresar</button>
+  </form>
+{% endblock %}

--- a/core/urls.py
+++ b/core/urls.py
@@ -2,5 +2,6 @@ from django.urls import path
 from . import views
 
 urlpatterns = [
-    path('', views.formulario_view, name='formulario'),
+    path('', views.login_view, name='login'),
+    path('formulario/', views.formulario_view, name='formulario'),
 ]

--- a/core/views.py
+++ b/core/views.py
@@ -8,7 +8,25 @@ from django.core.mail import EmailMessage
 from io import BytesIO
 from PIL import Image
 
+def login_view(request):
+    """Simple login page using credentials from settings."""
+    error = False
+    if request.method == 'POST':
+        username = request.POST.get('username')
+        password = request.POST.get('password')
+        if username == settings.USUARIO_WEB and password == settings.PASSWORD_WEB:
+            request.session['authenticated'] = True
+            request.session['usuario'] = username
+            return redirect('formulario')
+        error = True
+    return render(request, 'core/login.html', {
+        'error': error,
+        'nombre': request.session.get('usuario')
+    })
+
 def formulario_view(request):
+    if not request.session.get('authenticated'):
+        return redirect('login')
     if request.method == 'POST':
         form = ReporteForm(request.POST, request.FILES)
         if form.is_valid():
@@ -105,4 +123,5 @@ def formulario_view(request):
     return render(request, 'core/formulario.html', {
         'form': form,
         'mensaje_exito': mensaje_exito,
+        'nombre': request.session.get('usuario'),
     })

--- a/reportes/settings.py
+++ b/reportes/settings.py
@@ -4,6 +4,8 @@ import os
 BASE_DIR = Path(__file__).resolve().parent.parent
 
 SECRET_KEY = os.environ.get('SECRET_KEY', 'tu-secret-key')
+USUARIO_WEB = os.environ.get('Usuario_Web', 'usuario')
+PASSWORD_WEB = os.environ.get('Password_Web', 'password')
 DEBUG = False
 
 ALLOWED_HOSTS = [

--- a/reportes/urls.py
+++ b/reportes/urls.py
@@ -5,8 +5,8 @@ from django.conf import settings
 from django.conf.urls.static import static
 
 urlpatterns = [
-    # Tu formulario en la raíz
-    path('', views.formulario_view, name='formulario'),
+    path('', views.login_view, name='login'),
+    path('formulario/', views.formulario_view, name='formulario'),
 ]
 
 # Esto sirve MEDIA_URL durante el DEBUG para que InlineImage funcione


### PR DESCRIPTION
## Summary
- require credentials from env `Usuario_Web` and `Password_Web`
- add login view and template matching existing style
- restrict form view to logged in sessions
- update URLs to start at login page

## Testing
- `python manage.py check`
- `python manage.py migrate`

------
https://chatgpt.com/codex/tasks/task_e_6855f0c48570833087ae449a2505bb99