### PR TITLE
Fix persistent success message

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -27,6 +27,9 @@ def login_view(request):
 def formulario_view(request):
     if not request.session.get('authenticated'):
         return redirect('login')
+
+    nombre = request.session.get('usuario')
+
     if request.method == 'POST':
         form = ReporteForm(request.POST, request.FILES)
         if form.is_valid():
@@ -120,8 +123,11 @@ def formulario_view(request):
         form = ReporteForm()
 
     mensaje_exito = request.GET.get('success') == '1'
+    if mensaje_exito:
+        request.session.flush()
+
     return render(request, 'core/formulario.html', {
         'form': form,
         'mensaje_exito': mensaje_exito,
-        'nombre': request.session.get('usuario'),
+        'nombre': nombre,
     })


### PR DESCRIPTION
## Summary
- flush session when returning to the form page after generating the report
- keep user name for the success page

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python manage.py check`

------
https://chatgpt.com/codex/tasks/task_e_6855f8ecfb848330922567b75a90ad57