### PR TITLE
Add mobile dropdown navigation

### DIFF
--- a/core/static/css/style.css
+++ b/core/static/css/style.css
@@ -47,6 +47,16 @@ body {
 .main-nav a.active {
   background: var(--color-secondary);
 }
+.nav-select {
+  display: none;
+  margin-left: 1rem;
+  padding: 0.5rem;
+  border-radius: 0.25rem;
+  font-size: 1rem;
+}
+.nav-select:focus {
+  outline: none;
+}
 .user-info {
   color: #fff;
   font-size: 0.9rem;
@@ -138,4 +148,16 @@ hr {
   color: red;
   text-align: center;
   margin-bottom: 1rem;
+}
+
+@media (max-width: 600px) {
+  .main-nav {
+    display: none;
+  }
+  .nav-select {
+    display: block;
+  }
+  .header-container {
+    flex-wrap: wrap;
+  }
 }

--- a/core/templates/base.html
+++ b/core/templates/base.html
@@ -13,10 +13,14 @@
       <a href="#" class="logo">
         <img src="{% static 'images/aediles_logo.png' %}" alt="Aediles" height="40">
       </a>
-      <nav class="main-nav">
-        <a href="{% url 'formulario' %}" class="{% if active_tab == 'formulario' %}active{% endif %}">Inspección Rutinaria</a>
-        <a href="{% url 'actividades' %}" class="{% if active_tab == 'actividades' %}active{% endif %}">Reporte Actividades</a>
-      </nav>
+        <nav class="main-nav">
+          <a href="{% url 'formulario' %}" class="{% if active_tab == 'formulario' %}active{% endif %}">Inspección Rutinaria</a>
+          <a href="{% url 'actividades' %}" class="{% if active_tab == 'actividades' %}active{% endif %}">Reporte Actividades</a>
+        </nav>
+        <select id="nav-select" class="nav-select">
+          <option value="{% url 'formulario' %}" {% if active_tab == 'formulario' %}selected{% endif %}>Inspección Rutinaria</option>
+          <option value="{% url 'actividades' %}" {% if active_tab == 'actividades' %}selected{% endif %}>Reporte Actividades</option>
+        </select>
       {% if nombre %}
       <div class="user-info">
         Bienvenido(a), {{ nombre }}
@@ -28,5 +32,15 @@
   <div class="container">
     {% block content %}{% endblock %}
   </div>
+  <script>
+    document.addEventListener('DOMContentLoaded', function() {
+      var navSelect = document.getElementById('nav-select');
+      if (navSelect) {
+        navSelect.addEventListener('change', function() {
+          window.location.href = this.value;
+        });
+      }
+    });
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- use dropdown on small screens instead of stacked navigation links
- hide nav links on phone resolution
- add simple JS handler for dropdown

## Testing
- `python manage.py check`


------
https://chatgpt.com/codex/tasks/task_e_68561116a3508330b734a2114b7c8f97