### PR TITLE
Ocultar navegación hasta autenticación

### DIFF
--- a/core/templates/base.html
+++ b/core/templates/base.html
@@ -13,6 +13,7 @@
       <a href="#" class="logo">
         <img src="{% static 'images/aediles_logo.png' %}" alt="Aediles" height="40">
       </a>
+        {% if nombre %}
         <nav class="main-nav">
           <a href="{% url 'formulario' %}" class="{% if active_tab == 'formulario' %}active{% endif %}">Inspección Rutinaria</a>
           <a href="{% url 'actividades' %}" class="{% if active_tab == 'actividades' %}active{% endif %}">Reporte Actividades</a>
@@ -21,11 +22,10 @@
           <option value="{% url 'formulario' %}" {% if active_tab == 'formulario' %}selected{% endif %}>Inspección Rutinaria</option>
           <option value="{% url 'actividades' %}" {% if active_tab == 'actividades' %}selected{% endif %}>Reporte Actividades</option>
         </select>
-      {% if nombre %}
-      <div class="user-info">
-        Bienvenido(a), {{ nombre }}
-      </div>
-      {% endif %}
+        <div class="user-info">
+          Bienvenido(a), {{ nombre }}
+        </div>
+        {% endif %}
     </div>
   </header>
 

--- a/core/views.py
+++ b/core/views.py
@@ -11,6 +11,10 @@ from PIL import Image
 def login_view(request):
     """Simple login page using credentials from settings."""
     error = False
+    if request.method == 'GET':
+        # Clear any existing session so the navigation
+        # menu remains hidden on the login page
+        request.session.flush()
     if request.method == 'POST':
         username = request.POST.get('username')
         password = request.POST.get('password')


### PR DESCRIPTION
## Summary
- hide navigation bar until user is logged in
- flush session on initial GET to login so nav remains hidden when returning to login page

## Testing
- `python manage.py check` *(shows only staticfiles warning)*

------
https://chatgpt.com/codex/tasks/task_e_685705139df883309f93d51abdb7b866