### PR TITLE
Add custom filename field to forms

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -17,6 +17,13 @@ class ReporteForm(forms.Form):
     parque = forms.CharField(max_length=100, widget=forms.TextInput(attrs={
         'class': 'form-control',
     }))
+    nombre_archivo = forms.CharField(
+        label='Nombre del documento',
+        max_length=100,
+        widget=forms.TextInput(attrs={
+            'class': 'form-control',
+        })
+    )
 
     # Nuevo: destinatario opcional
     destinatario = forms.EmailField(
@@ -187,6 +194,13 @@ class ActividadesForm(forms.Form):
     parque = forms.CharField(max_length=100, widget=forms.TextInput(attrs={
         'class': 'form-control',
     }))
+    nombre_archivo = forms.CharField(
+        label='Nombre del documento',
+        max_length=100,
+        widget=forms.TextInput(attrs={
+            'class': 'form-control',
+        })
+    )
 
     destinatario = forms.EmailField(
         required=False,

--- a/core/templates/core/formulario.html
+++ b/core/templates/core/formulario.html
@@ -27,6 +27,11 @@
       {{ form.parque.errors }}
     </div>
     <div class="form-group">
+      {{ form.nombre_archivo.label_tag }}
+      {{ form.nombre_archivo|add_class:"form-control" }}
+      {{ form.nombre_archivo.errors }}
+    </div>
+    <div class="form-group">
       {{ form.destinatario.label_tag }}
       {{ form.destinatario|add_class:"form-control" }}
       {{ form.destinatario.errors }}

--- a/core/templates/core/reporte_actividades.html
+++ b/core/templates/core/reporte_actividades.html
@@ -26,6 +26,11 @@
       {{ form.parque.errors }}
     </div>
     <div class="form-group">
+      {{ form.nombre_archivo.label_tag }}
+      {{ form.nombre_archivo|add_class:"form-control" }}
+      {{ form.nombre_archivo.errors }}
+    </div>
+    <div class="form-group">
       {{ form.destinatario.label_tag }}
       {{ form.destinatario|add_class:"form-control" }}
       {{ form.destinatario.errors }}

--- a/core/views.py
+++ b/core/views.py
@@ -111,8 +111,9 @@ def formulario_view(request):
                         from_email=settings.DEFAULT_FROM_EMAIL,
                         to=[dest],
                     )
+                    file_name = f"{cd['fecha'].strftime('%y-%m-%d')}_{cd['parque']}_{cd['nombre_archivo']}.docx"
                     mail.attach(
-                        filename=f"informe_{cd['parque']}.docx",
+                        filename=file_name,
                         content=data,
                         mimetype='application/vnd.openxmlformats-officedocument.wordprocessingml.document'
                     )
@@ -191,8 +192,9 @@ def actividades_view(request):
                         from_email=settings.DEFAULT_FROM_EMAIL,
                         to=[dest],
                     )
+                    file_name = f"{cd['fecha'].strftime('%y-%m-%d')}_{cd['parque']}_{cd['nombre_archivo']}.docx"
                     mail.attach(
-                        filename=f"reporte_actividades_{cd['parque']}.docx",
+                        filename=file_name,
                         content=data,
                         mimetype='application/vnd.openxmlformats-officedocument.wordprocessingml.document'
                     )


### PR DESCRIPTION
## Summary
- allow custom file names in `ReporteForm` and `ActividadesForm`
- display new field in both templates below the park name
- generate attachment names using date, park and custom text

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python manage.py check`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_686b0180138c83309ad1ac861d41b80e