### PR TITLE
Surface email send failures in report delivery

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -104,22 +104,19 @@ def formulario_view(request):
             # Email condicional
             dest = cd.get('destinatario')
             if dest:
-                try:
-                    mail = EmailMessage(
-                        subject=f"Reporte inspección {cd['parque']} realizado por {cd['nombre']}",
-                        body="Reporte adjunto",
-                        from_email=settings.DEFAULT_FROM_EMAIL,
-                        to=[dest],
-                    )
-                    file_name = f"{cd['fecha'].strftime('%y-%m-%d')}_{cd['parque']}_{cd['nombre_archivo']}.docx"
-                    mail.attach(
-                        filename=file_name,
-                        content=data,
-                        mimetype='application/vnd.openxmlformats-officedocument.wordprocessingml.document'
-                    )
-                    mail.send(fail_silently=True)
-                except:
-                    pass
+                mail = EmailMessage(
+                    subject=f"Reporte inspección {cd['parque']} realizado por {cd['nombre']}",
+                    body="Reporte adjunto",
+                    from_email=settings.DEFAULT_FROM_EMAIL,
+                    to=[dest],
+                )
+                file_name = f"{cd['fecha'].strftime('%y-%m-%d')}_{cd['parque']}_{cd['nombre_archivo']}.docx"
+                mail.attach(
+                    filename=file_name,
+                    content=data,
+                    mimetype='application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+                )
+                mail.send(fail_silently=False)
 
             # Redirigir para evitar reenvío al refrescar
             return redirect(f"{reverse('formulario')}?success=1")
@@ -185,22 +182,19 @@ def actividades_view(request):
 
             dest = cd.get('destinatario')
             if dest:
-                try:
-                    mail = EmailMessage(
-                        subject=f"Reporte actividades {cd['parque']} realizado por {cd['nombre']}",
-                        body="Reporte adjunto",
-                        from_email=settings.DEFAULT_FROM_EMAIL,
-                        to=[dest],
-                    )
-                    file_name = f"{cd['fecha'].strftime('%y-%m-%d')}_{cd['parque']}_{cd['nombre_archivo']}.docx"
-                    mail.attach(
-                        filename=file_name,
-                        content=data,
-                        mimetype='application/vnd.openxmlformats-officedocument.wordprocessingml.document'
-                    )
-                    mail.send(fail_silently=True)
-                except:
-                    pass
+                mail = EmailMessage(
+                    subject=f"Reporte actividades {cd['parque']} realizado por {cd['nombre']}",
+                    body="Reporte adjunto",
+                    from_email=settings.DEFAULT_FROM_EMAIL,
+                    to=[dest],
+                )
+                file_name = f"{cd['fecha'].strftime('%y-%m-%d')}_{cd['parque']}_{cd['nombre_archivo']}.docx"
+                mail.attach(
+                    filename=file_name,
+                    content=data,
+                    mimetype='application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+                )
+                mail.send(fail_silently=False)
 
             return redirect(f"{reverse('actividades')}?success=1")
     else:


### PR DESCRIPTION
### Motivation

- Stop silently swallowing exceptions when sending report emails so SMTP issues are visible and debuggable.
- Ensure email delivery failures raise errors instead of being ignored for both inspection and activities report flows.

### Description

- Updated `core/views.py` to remove broad `try/except` blocks around email sending in both report flows.
- Changed `mail.send` to `mail.send(fail_silently=False)` so send failures surface.
- Kept existing attachment logic and message content unchanged while surfacing errors.

### Testing

- No automated tests were run for this change.
- CI was not executed as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69504483c3ac833083bb7b5fdd25df89)